### PR TITLE
Naughty editor removed the <%= from the wildfly sysconfig template which...

### DIFF
--- a/templates/etc/sysconfig/wildfly.erb
+++ b/templates/etc/sysconfig/wildfly.erb
@@ -35,7 +35,7 @@ SHUTDOWN_WAIT=60
 JBOSS_CONSOLE_LOG="/var/log/wildfly/console.log"
 
 JAVA_OPTS="-Djboss.server.base.dir=${JBOSS_BASE_DIR} -Djboss.server.log.dir=${JBOSS_LOG_DIR} -Djboss.server.config.dir=${JBOSS_CONFIG_DIR}"
-JAVA_OPTS="$JAVA_OPTS -Xms<%= @jboss_min_mem %>m -Xmx<%= @jboss_max_mem %>m -XX:PermSize=<%= @jboss_perm %> -XX:MaxPermSize=<%= @jboss_max_perm %>m -Djava.net.preferIPv4Stack=true"
+JAVA_OPTS="$JAVA_OPTS -Xms<%= @jboss_min_mem %>m -Xmx<%= @jboss_max_mem %>m -XX:PermSize=<%= @jboss_perm %>m -XX:MaxPermSize=<%= @jboss_max_perm %>m -Djava.net.preferIPv4Stack=true"
 JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
 JAVA_OPTS="$JAVA_OPTS -Djboss.bind.address=<%= @jboss_bind_address %> -Djboss.bind.address.unsecure=<%= @jboss_bind_address %> -Djboss.bind.address.management=<%= @jboss_bind_address_mgmt %>"
 <%- if @jboss_debug -%>


### PR DESCRIPTION
... results in empty memory settings (what happened?!)
