### PR TITLE
[WILDFLY] change filepermissions to 664 because of umask change for wildfly systemd config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -115,7 +115,7 @@ class wildfly::config(
 
   file { "${jboss_base_dir_real}/configuration/${jboss_config}.xml":
     ensure  => file,
-    mode    => '0644',
+    mode    => '0664',
     owner   => $jboss_user,
     group   => $jboss_group,
     replace => false,


### PR DESCRIPTION
do not merge without checking puppet agent state in acc and prd! needs to be disabled to guarantee a controlled rollout.